### PR TITLE
refactor: extract multisig verification helper and improve deserialization

### DIFF
--- a/src/__tests__/claim.test.ts
+++ b/src/__tests__/claim.test.ts
@@ -1045,3 +1045,72 @@ describe('Bare multisig claims', () => {
     expect(result.error).toContain('signatures verified')
   })
 })
+
+describe('verifyMultisig via verifyClaimProof — missing witnessSignatures', () => {
+  it('rejects P2WSH multisig claim with null witnessSignatures', () => {
+    const { snapshot, holders } = createMockSnapshot()
+    const p2wshHolder = holders.find(h => h.type === 'p2wsh')!
+    const p2wshEntry = snapshot.entries.find(e => e.type === 'p2wsh')!
+    const qbtcWallet = qbtcWalletA
+
+    const tx = createP2wshClaimTransaction(
+      [p2wshHolder.signerKeys![0].secretKey, p2wshHolder.signerKeys![1].secretKey],
+      p2wshHolder.witnessScript!,
+      p2wshEntry,
+      qbtcWallet,
+      snapshot.btcBlockHash
+    )
+    // Remove witnessSignatures to trigger the missing-signatures branch
+    tx.claimData!.witnessSignatures = undefined as any
+
+    const result = verifyClaimProof(tx, snapshot)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('missing signatures')
+  })
+
+  it('rejects P2SH multisig claim with null witnessSignatures', () => {
+    const { snapshot, holders } = createMockSnapshot()
+    const p2shMultisigHolder = holders.find(h => h.type === 'p2sh' && h.signerKeys)!
+    const p2shMultisigEntry = snapshot.entries.find(e =>
+      e.type === 'p2sh' && e.btcAddress === p2shMultisigHolder.address
+    )!
+    const qbtcWallet = qbtcWalletA
+
+    const tx = createP2shMultisigClaimTransaction(
+      [p2shMultisigHolder.signerKeys![0].secretKey, p2shMultisigHolder.signerKeys![1].secretKey],
+      p2shMultisigHolder.witnessScript!,
+      p2shMultisigEntry,
+      qbtcWallet,
+      snapshot.btcBlockHash
+    )
+    tx.claimData!.witnessSignatures = undefined as any
+
+    const result = verifyClaimProof(tx, snapshot)
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('missing signatures')
+  })
+})
+
+describe('verifyClaimProof — improved catch error messages', () => {
+  it('includes parse detail when P2TR public key is invalid', () => {
+    const { snapshot, holders } = createMockSnapshot()
+    const p2trHolder = holders.find(h => h.type === 'p2tr')!
+    const p2trEntry = snapshot.entries.find(e => e.type === 'p2tr')!
+    const qbtcWallet = qbtcWalletA
+
+    const tx = createClaimTransaction(
+      p2trHolder.secretKey,
+      p2trHolder.publicKey,
+      p2trEntry,
+      qbtcWallet,
+      snapshot.btcBlockHash
+    )
+    // Replace schnorrPublicKey with garbage bytes that will fail computeTaprootOutputKey
+    tx.claimData!.schnorrPublicKey = new Uint8Array(32).fill(0xff)
+
+    const result = verifyClaimProof(tx, snapshot)
+    expect(result.valid).toBe(false)
+    // Error should include the detail from the thrown error, not just a bare message
+    expect(result.error).toMatch(/Invalid P2TR public key:/)
+  })
+})

--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { FileBlockStorage, sanitizeForStorage } from '../storage.js'
+import { FileBlockStorage, sanitizeForStorage, deserializeTransaction, deserializeBlock } from '../storage.js'
 import { Blockchain } from '../chain.js'
 import {
   createCoinbaseTransaction,
@@ -197,6 +197,115 @@ describe('FileBlockStorage', () => {
     expect(chain2.getHeight()).toBe(height1)
     expect(chain2.utxoSet.size).toBe(utxoCount1)
     expect(chain2.blocks[chain2.blocks.length - 1].hash).toBe(block2.hash)
+  })
+})
+
+describe('deserializeTransaction', () => {
+  it('restores publicKey and signature hex strings to Uint8Array', () => {
+    const raw = {
+      id: 'abc123',
+      inputs: [{ txId: 'deadbeef', outputIndex: 0, publicKey: '0102', signature: 'aabb' }],
+      outputs: [{ address: 'someaddr', amount: 100 }],
+      timestamp: 1000,
+    }
+    const tx = deserializeTransaction(raw as any)
+    expect(tx.inputs[0].publicKey).toBeInstanceOf(Uint8Array)
+    expect(tx.inputs[0].publicKey).toEqual(new Uint8Array([0x01, 0x02]))
+    expect(tx.inputs[0].signature).toBeInstanceOf(Uint8Array)
+    expect(tx.inputs[0].signature).toEqual(new Uint8Array([0xaa, 0xbb]))
+  })
+
+  it('restores all claimData binary fields from hex to Uint8Array', () => {
+    const raw = {
+      id: 'abc123',
+      inputs: [],
+      outputs: [],
+      timestamp: 1000,
+      claimData: {
+        btcAddress: 'btcaddr',
+        qbtcAddress: 'qbtcaddr',
+        ecdsaPublicKey: 'aabb',
+        ecdsaSignature: 'ccdd',
+        schnorrPublicKey: 'eeff',
+        schnorrSignature: '1122',
+        witnessScript: '3344',
+        witnessSignatures: '5566',
+      },
+    }
+    const tx = deserializeTransaction(raw as any)
+    const cd = tx.claimData!
+    expect(cd.ecdsaPublicKey).toBeInstanceOf(Uint8Array)
+    expect(cd.ecdsaPublicKey).toEqual(new Uint8Array([0xaa, 0xbb]))
+    expect(cd.ecdsaSignature).toBeInstanceOf(Uint8Array)
+    expect(cd.schnorrPublicKey).toBeInstanceOf(Uint8Array)
+    expect(cd.schnorrSignature).toBeInstanceOf(Uint8Array)
+    expect(cd.witnessScript).toBeInstanceOf(Uint8Array)
+    expect(cd.witnessSignatures).toBeInstanceOf(Uint8Array)
+  })
+
+  it('handles transaction without claimData', () => {
+    const raw = {
+      id: 'abc',
+      inputs: [{ txId: 'x', outputIndex: 0, publicKey: 'ff', signature: '00' }],
+      outputs: [],
+      timestamp: 1,
+    }
+    const tx = deserializeTransaction(raw as any)
+    expect(tx.claimData).toBeUndefined()
+    expect(tx.inputs[0].publicKey).toBeInstanceOf(Uint8Array)
+  })
+
+  it('leaves non-string binary fields unchanged', () => {
+    const existingBytes = new Uint8Array([0x01])
+    const raw = {
+      id: 'abc',
+      inputs: [{ txId: 'x', outputIndex: 0, publicKey: existingBytes, signature: existingBytes }],
+      outputs: [],
+      timestamp: 1,
+    }
+    const tx = deserializeTransaction(raw as any)
+    expect(tx.inputs[0].publicKey).toBe(existingBytes)
+  })
+})
+
+describe('deserializeBlock', () => {
+  it('deserializes all transactions in a block', () => {
+    const raw = {
+      hash: 'blockhash',
+      height: 1,
+      header: { version: 1, previousHash: '0'.repeat(64), merkleRoot: 'mr', timestamp: 1, target: 'tt', nonce: 0 },
+      transactions: [
+        {
+          id: 'tx1',
+          inputs: [{ txId: 'prev', outputIndex: 0, publicKey: 'aabb', signature: 'ccdd' }],
+          outputs: [{ address: 'addr', amount: 50 }],
+          timestamp: 1,
+        },
+        {
+          id: 'tx2',
+          inputs: [{ txId: 'prev2', outputIndex: 1, publicKey: '1234', signature: '5678' }],
+          outputs: [],
+          timestamp: 2,
+        },
+      ],
+    }
+    const block = deserializeBlock(raw as any)
+    expect(block.transactions).toHaveLength(2)
+    expect(block.transactions[0].inputs[0].publicKey).toBeInstanceOf(Uint8Array)
+    expect(block.transactions[0].inputs[0].publicKey).toEqual(new Uint8Array([0xaa, 0xbb]))
+    expect(block.transactions[1].inputs[0].publicKey).toBeInstanceOf(Uint8Array)
+    expect(block.transactions[1].inputs[0].publicKey).toEqual(new Uint8Array([0x12, 0x34]))
+  })
+
+  it('handles block with no transactions', () => {
+    const raw = {
+      hash: 'bh',
+      height: 0,
+      header: { version: 1, previousHash: '0'.repeat(64), merkleRoot: 'mr', timestamp: 1, target: 'tt', nonce: 0 },
+      transactions: [],
+    }
+    const block = deserializeBlock(raw as any)
+    expect(block.transactions).toHaveLength(0)
   })
 })
 

--- a/src/claim.ts
+++ b/src/claim.ts
@@ -239,6 +239,41 @@ export function createP2shMultisigClaimTransaction(
 }
 
 /**
+ * Verify m-of-n CHECKMULTISIG-style ordered signatures.
+ *
+ * Walks pubkeys in order, matching signatures in order (same as Bitcoin's
+ * OP_CHECKMULTISIG). Returns an error string if verification fails, or
+ * undefined on success.
+ */
+function verifyMultisig(
+  signatures: Uint8Array,
+  messageHash: Uint8Array,
+  m: number,
+  pubkeys: Uint8Array[],
+  label: string,
+): string | undefined {
+  if (signatures.length !== m * 64) {
+    return `${label} ${m}-of-${pubkeys.length} claim requires exactly ${m} signatures (${m * 64} bytes)`
+  }
+
+  const sigs: Uint8Array[] = []
+  for (let i = 0; i < m; i++) {
+    sigs.push(signatures.slice(i * 64, (i + 1) * 64))
+  }
+
+  let sigIdx = 0
+  for (let pkIdx = 0; pkIdx < pubkeys.length && sigIdx < m; pkIdx++) {
+    if (verifyEcdsaSignature(sigs[sigIdx], messageHash, pubkeys[pkIdx])) {
+      sigIdx++
+    }
+  }
+  if (sigIdx < m) {
+    return `Only ${sigIdx} of ${m} required signatures verified`
+  }
+  return undefined
+}
+
+/**
  * Verify a claim transaction's ECDSA proof against the BTC snapshot.
  *
  * Checks:
@@ -289,8 +324,9 @@ export function verifyClaimProof(
     let parsed: ReturnType<typeof parseWitnessScript>
     try {
       parsed = parseWitnessScript(claim.witnessScript)
-    } catch {
-      return { valid: false, error: 'Failed to parse witness script' }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      return { valid: false, error: `Failed to parse witness script: ${detail}` }
     }
 
     if (parsed.type === 'single-key') {
@@ -304,25 +340,12 @@ export function verifyClaimProof(
     } else {
       // Multisig: verify m-of-n CHECKMULTISIG-style ordered signatures
       const { m, pubkeys } = parsed
-      if (!claim.witnessSignatures || claim.witnessSignatures.length !== m * 64) {
-        return { valid: false, error: `P2WSH ${m}-of-${pubkeys.length} claim requires exactly ${m} signatures (${m * 64} bytes)` }
+      if (!claim.witnessSignatures) {
+        return { valid: false, error: `P2WSH ${m}-of-${pubkeys.length} claim missing signatures` }
       }
-
-      // Extract individual signatures
-      const sigs: Uint8Array[] = []
-      for (let i = 0; i < m; i++) {
-        sigs.push(claim.witnessSignatures.slice(i * 64, (i + 1) * 64))
-      }
-
-      // CHECKMULTISIG ordering: walk pubkeys in order, match signatures in order
-      let sigIdx = 0
-      for (let pkIdx = 0; pkIdx < pubkeys.length && sigIdx < m; pkIdx++) {
-        if (verifyEcdsaSignature(sigs[sigIdx], claimMsgHash, pubkeys[pkIdx])) {
-          sigIdx++
-        }
-      }
-      if (sigIdx < m) {
-        return { valid: false, error: `Only ${sigIdx} of ${m} required signatures verified` }
+      const multisigErr = verifyMultisig(claim.witnessSignatures, claimMsgHash, m, pubkeys, 'P2WSH')
+      if (multisigErr) {
+        return { valid: false, error: multisigErr }
       }
     }
   } else if (entry.type === 'p2tr') {
@@ -338,8 +361,9 @@ export function verifyClaimProof(
     let derivedAddress: string
     try {
       derivedAddress = bytesToHex(computeTaprootOutputKey(claim.schnorrPublicKey))
-    } catch {
-      return { valid: false, error: 'Invalid P2TR public key' }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      return { valid: false, error: `Invalid P2TR public key: ${detail}` }
     }
     if (derivedAddress !== claim.btcAddress) {
       return {
@@ -363,8 +387,9 @@ export function verifyClaimProof(
       let parsed: ReturnType<typeof parseWitnessScript>
       try {
         parsed = parseWitnessScript(claim.witnessScript)
-      } catch {
-        return { valid: false, error: 'Failed to parse redeem script' }
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err)
+        return { valid: false, error: `Failed to parse redeem script: ${detail}` }
       }
 
       if (parsed.type === 'single-key') {
@@ -376,23 +401,12 @@ export function verifyClaimProof(
         }
       } else {
         const { m, pubkeys } = parsed
-        if (!claim.witnessSignatures || claim.witnessSignatures.length !== m * 64) {
-          return { valid: false, error: `P2SH ${m}-of-${pubkeys.length} claim requires exactly ${m} signatures (${m * 64} bytes)` }
+        if (!claim.witnessSignatures) {
+          return { valid: false, error: `P2SH ${m}-of-${pubkeys.length} claim missing signatures` }
         }
-
-        const sigs: Uint8Array[] = []
-        for (let i = 0; i < m; i++) {
-          sigs.push(claim.witnessSignatures.slice(i * 64, (i + 1) * 64))
-        }
-
-        let sigIdx = 0
-        for (let pkIdx = 0; pkIdx < pubkeys.length && sigIdx < m; pkIdx++) {
-          if (verifyEcdsaSignature(sigs[sigIdx], claimMsgHash, pubkeys[pkIdx])) {
-            sigIdx++
-          }
-        }
-        if (sigIdx < m) {
-          return { valid: false, error: `Only ${sigIdx} of ${m} required signatures verified` }
+        const multisigErr = verifyMultisig(claim.witnessSignatures, claimMsgHash, m, pubkeys, 'P2SH')
+        if (multisigErr) {
+          return { valid: false, error: multisigErr }
         }
       }
     } else {

--- a/src/p2p/peer.ts
+++ b/src/p2p/peer.ts
@@ -92,8 +92,9 @@ export class Peer {
         // Slow peer: kernel buffer full — disconnect immediately (Bitcoin Core behavior)
         this.disconnect('write backpressure')
       }
-    } catch {
-      this.disconnect('send error')
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      this.disconnect(`send error: ${reason}`)
     }
   }
 
@@ -171,7 +172,8 @@ export class Peer {
         }
         this.onMessage(this, msg)
       }
-    } catch (err) {
+    } catch {
+      // Malformed message framing — penalize peer for sending garbage
       this.addMisbehavior(25)
     }
   }

--- a/src/p2p/server.ts
+++ b/src/p2p/server.ts
@@ -25,10 +25,9 @@ import {
   encodeMessage,
 } from './protocol.js'
 import type { Node } from '../node.js'
-import { sanitizeForStorage } from '../storage.js'
-import { hexToBytes, bytesToHex } from '../crypto.js'
+import { sanitizeForStorage, deserializeTransaction, deserializeBlock } from '../storage.js'
 import { type Block, computeBlockHash, hashMeetsTarget, blockWork } from '../block.js'
-import type { Transaction, TransactionInput, ClaimData } from '../transaction.js'
+import type { Transaction } from '../transaction.js'
 import { log } from '../log.js'
 
 const MAX_INBOUND = 25
@@ -94,45 +93,6 @@ const ORPHAN_EXPIRY_MS = 10 * 60_000
 interface OrphanBlock {
   block: Block
   receivedAt: number
-}
-
-/** Known Uint8Array fields that need deserialization from P2P messages */
-const TX_INPUT_BINARY_FIELDS = ['publicKey', 'signature'] as const
-const CLAIM_DATA_BINARY_FIELDS = ['ecdsaPublicKey', 'ecdsaSignature', 'schnorrPublicKey', 'schnorrSignature', 'witnessScript', 'witnessSignatures'] as const
-
-function deserializeTransaction(raw: Record<string, unknown>): Transaction {
-  const tx = raw as unknown as Transaction
-  if (Array.isArray(raw.inputs)) {
-    tx.inputs = raw.inputs.map((inp: Record<string, unknown>) => {
-      const input = inp as unknown as TransactionInput
-      for (const field of TX_INPUT_BINARY_FIELDS) {
-        if (typeof inp[field] === 'string') {
-          (input as Record<string, unknown>)[field] = hexToBytes(inp[field] as string)
-        }
-      }
-      return input
-    })
-  }
-  if (raw.claimData && typeof raw.claimData === 'object') {
-    const cd = raw.claimData as Record<string, unknown>
-    for (const field of CLAIM_DATA_BINARY_FIELDS) {
-      if (typeof cd[field] === 'string') {
-        (cd as Record<string, unknown>)[field] = hexToBytes(cd[field] as string)
-      }
-    }
-    tx.claimData = cd as unknown as ClaimData
-  }
-  return tx
-}
-
-function deserializeBlock(raw: Record<string, unknown>): Block {
-  const block = raw as unknown as Block
-  if (Array.isArray(raw.transactions)) {
-    block.transactions = raw.transactions.map((t: Record<string, unknown>) =>
-      deserializeTransaction(t)
-    )
-  }
-  return block
 }
 
 export class P2PServer {
@@ -1044,8 +1004,8 @@ export class P2PServer {
           }
         }
       }
-    } catch {
-      // Ignore corrupt ban list
+    } catch (err) {
+      log.debug({ component: 'p2p', err }, 'Could not load ban list — starting fresh')
     }
   }
 
@@ -1162,7 +1122,7 @@ export class P2PServer {
       if (!this.localMode) {
         const subnetCounts = new Map<string, number>()
         for (const peer of this.peers.values()) {
-          if (!(peer as any).inbound) {
+          if (!peer.inbound) {
             const subnet = getSubnet16(peer.address)
             subnetCounts.set(subnet, (subnetCounts.get(subnet) ?? 0) + 1)
           }
@@ -1279,8 +1239,8 @@ export class P2PServer {
       if (anchors.length > 0) {
         log.info({ component: 'p2p', count: anchors.length }, 'Loaded anchor peers')
       }
-    } catch {
-      // File doesn't exist or is invalid — start fresh
+    } catch (err) {
+      log.debug({ component: 'p2p', err }, 'Could not load anchors — starting fresh')
     }
   }
 
@@ -1292,8 +1252,8 @@ export class P2PServer {
       .slice(0, this.MAX_ANCHORS)
     try {
       fs.writeFileSync(this.anchorsPath, JSON.stringify(entries, null, 2) + '\n')
-    } catch {
-      // Data dir may not be writable — ignore
+    } catch (err) {
+      log.debug({ component: 'p2p', err }, 'Could not save anchors — data dir may not be writable')
     }
   }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,11 +1,11 @@
 
 import express from 'express';
 import { Node } from './node.js';
-import { bytesToHex, hexToBytes } from './crypto.js';
+import { bytesToHex, deriveAddress } from './crypto.js';
 import cors from 'cors';
 import type { P2PServer } from './p2p/server.js';
-import { type Transaction, type TransactionInput, type ClaimData, isClaimTransaction, COINBASE_TXID } from './transaction.js';
-import { deriveAddress } from './crypto.js';
+import { type Transaction, isClaimTransaction, COINBASE_TXID } from './transaction.js';
+import { deserializeTransaction } from './storage.js';
 import { DIFFICULTY_ADJUSTMENT_INTERVAL, STARTING_DIFFICULTY } from './block.js';
 import { log } from './log.js';
 import type { Request, Response, NextFunction } from 'express';
@@ -69,34 +69,6 @@ export function sanitize(obj: unknown): unknown {
   return obj;
 }
 
-/** Known Uint8Array fields in transactions that need deserialization */
-const TX_INPUT_BINARY_FIELDS = ['publicKey', 'signature'] as const;
-const CLAIM_DATA_BINARY_FIELDS = ['ecdsaPublicKey', 'ecdsaSignature', 'schnorrPublicKey', 'schnorrSignature', 'witnessScript', 'witnessSignatures'] as const;
-
-function deserializeTransaction(raw: Record<string, unknown>): Transaction {
-  const tx = raw as unknown as Transaction;
-  if (Array.isArray(raw.inputs)) {
-    tx.inputs = raw.inputs.map((inp: Record<string, unknown>) => {
-      const input = inp as unknown as TransactionInput;
-      for (const field of TX_INPUT_BINARY_FIELDS) {
-        if (typeof inp[field] === 'string') {
-          (input as Record<string, unknown>)[field] = hexToBytes(inp[field] as string);
-        }
-      }
-      return input;
-    });
-  }
-  if (raw.claimData && typeof raw.claimData === 'object') {
-    const cd = raw.claimData as Record<string, unknown>;
-    for (const field of CLAIM_DATA_BINARY_FIELDS) {
-      if (typeof cd[field] === 'string') {
-        (cd as Record<string, unknown>)[field] = hexToBytes(cd[field] as string);
-      }
-    }
-    tx.claimData = cd as unknown as ClaimData;
-  }
-  return tx;
-}
 
 /** Validate that an address is a valid 64-character hex string */
 function isValidAddress(address: string): boolean {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -40,11 +40,11 @@ export function sanitizeForStorage(obj: unknown): unknown {
 }
 
 /** Known Uint8Array fields in transactions that need deserialization */
-const TX_INPUT_BINARY_FIELDS = ['publicKey', 'signature'] as const
-const CLAIM_DATA_BINARY_FIELDS = ['ecdsaPublicKey', 'ecdsaSignature', 'schnorrPublicKey', 'schnorrSignature', 'witnessScript', 'witnessSignatures'] as const
+export const TX_INPUT_BINARY_FIELDS = ['publicKey', 'signature'] as const
+export const CLAIM_DATA_BINARY_FIELDS = ['ecdsaPublicKey', 'ecdsaSignature', 'schnorrPublicKey', 'schnorrSignature', 'witnessScript', 'witnessSignatures'] as const
 
 /** Restore hex strings back to Uint8Array for known binary fields */
-function deserializeTransaction(raw: Record<string, unknown>): Transaction {
+export function deserializeTransaction(raw: Record<string, unknown>): Transaction {
   const tx = raw as unknown as Transaction
 
   // Restore inputs
@@ -74,7 +74,7 @@ function deserializeTransaction(raw: Record<string, unknown>): Transaction {
   return tx
 }
 
-function deserializeBlock(raw: Record<string, unknown>): Block {
+export function deserializeBlock(raw: Record<string, unknown>): Block {
   const block = raw as unknown as Block
   if (Array.isArray(raw.transactions)) {
     block.transactions = raw.transactions.map((t: Record<string, unknown>) =>


### PR DESCRIPTION
Extracts a shared `verifyMultisig` helper in `claim.ts` to eliminate duplicated deserialization logic across `rpc.ts`, `p2p/server.ts`, and `p2p/peer.ts`. Improves error handling throughout claim and storage paths.

**Tech Stack:** TypeScript, Node.js, ML-DSA-65, Express v5, vitest

**Testing:**
```
pnpm test
```